### PR TITLE
Reorder GPIOs and add defines for disk LEDs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
 #AlignEscapedNewlines: Left # Unknown to clang-format-4.0
 AlignOperands: true
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -557,4 +557,4 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Cpp03
 TabWidth: 8
-UseTab: Always
+UseTab: AlignWithSpaces

--- a/asustor.c
+++ b/asustor.c
@@ -40,32 +40,32 @@
 // https://lore.kernel.org/linux-leds/20210819025053.222710-1-arequipeno@gmail.com/
 static struct gpio_led asustor_leds[] = {
 	{ .name		 = "power:front_panel",
-	  .default_state = LEDS_GPIO_DEFSTATE_ON }, // 1
-	{ .name = "power:lcd", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 2
-	{ .name = "blue:power", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 3
-	{ .name = "red:power", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 4
-	{ .name = "green:status", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 5
+	  .default_state = LEDS_GPIO_DEFSTATE_ON },			    // 0
+	{ .name = "power:lcd", .default_state = LEDS_GPIO_DEFSTATE_ON },    // 1
+	{ .name = "blue:power", .default_state = LEDS_GPIO_DEFSTATE_ON },   // 2
+	{ .name = "red:power", .default_state = LEDS_GPIO_DEFSTATE_OFF },   // 3
+	{ .name = "green:status", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 4
 	{
 		.name		 = "red:status",
 		.default_state	 = LEDS_GPIO_DEFSTATE_OFF,
 		.panic_indicator = 1,
 		.default_trigger = "panic",
-	}, // 6
-	{ .name = "blue:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 7
-	{ .name = "green:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 8
-	{ .name = "blue:lan", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 9
-	DISK_ACT_LED("sata1"), // 10
-	DISK_ERR_LED("sata1"), // 11
-	DISK_ACT_LED("sata2"), // 12
-	DISK_ERR_LED("sata2"), // 13
-	DISK_ACT_LED("sata3"), // 14
-	DISK_ERR_LED("sata3"), // 15
-	DISK_ACT_LED("sata4"), // 16
-	DISK_ERR_LED("sata4"), // 17
-	DISK_ACT_LED("sata5"), // 18
-	DISK_ERR_LED("sata5"), // 19
-	DISK_ACT_LED("sata6"), // 20
-	DISK_ERR_LED("sata6"), // 21
+	},								  // 5
+	{ .name = "blue:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF },  // 6
+	{ .name = "green:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 7
+	{ .name = "blue:lan", .default_state = LEDS_GPIO_DEFSTATE_ON },	  // 8
+	DISK_ACT_LED("sata1"),						  // 9
+	DISK_ERR_LED("sata1"),						  // 10
+	DISK_ACT_LED("sata2"),						  // 11
+	DISK_ERR_LED("sata2"),						  // 12
+	DISK_ACT_LED("sata3"),						  // 13
+	DISK_ERR_LED("sata3"),						  // 14
+	DISK_ACT_LED("sata4"),						  // 15
+	DISK_ERR_LED("sata4"),						  // 16
+	DISK_ACT_LED("sata5"),						  // 17
+	DISK_ERR_LED("sata5"),						  // 18
+	DISK_ACT_LED("sata6"),						  // 19
+	DISK_ERR_LED("sata6"),						  // 20
 };
 
 static const struct gpio_led_platform_data asustor_leds_pdata = {

--- a/asustor.c
+++ b/asustor.c
@@ -25,13 +25,13 @@
 
 #define DISK_ACT_LED(_name)                                                    \
 	{                                                                      \
-		.name		 = _name ":green:disk",                        \
-		.default_state	 = LEDS_GPIO_DEFSTATE_ON,                      \
+		.name            = _name ":green:disk",                        \
+		.default_state   = LEDS_GPIO_DEFSTATE_ON,                      \
 		.default_trigger = "disk-activity"                             \
 	}
 #define DISK_ERR_LED(_name)                                                    \
 	{                                                                      \
-		.name	       = _name ":red:disk",                            \
+		.name          = _name ":red:disk",                            \
 		.default_state = LEDS_GPIO_DEFSTATE_OFF                        \
 	}
 
@@ -39,37 +39,37 @@
 // If ledtrig-blkdev ever lands, use that instead of disk-activity:
 // https://lore.kernel.org/linux-leds/20210819025053.222710-1-arequipeno@gmail.com/
 static struct gpio_led asustor_leds[] = {
-	{ .name		 = "power:front_panel",
-	  .default_state = LEDS_GPIO_DEFSTATE_ON },			    // 0
+	{ .name          = "power:front_panel",
+	  .default_state = LEDS_GPIO_DEFSTATE_ON },                         // 0
 	{ .name = "power:lcd", .default_state = LEDS_GPIO_DEFSTATE_ON },    // 1
 	{ .name = "blue:power", .default_state = LEDS_GPIO_DEFSTATE_ON },   // 2
 	{ .name = "red:power", .default_state = LEDS_GPIO_DEFSTATE_OFF },   // 3
 	{ .name = "green:status", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 4
 	{
-		.name		 = "red:status",
-		.default_state	 = LEDS_GPIO_DEFSTATE_OFF,
+		.name            = "red:status",
+		.default_state   = LEDS_GPIO_DEFSTATE_OFF,
 		.panic_indicator = 1,
 		.default_trigger = "panic",
-	},								  // 5
+	},                                                                // 5
 	{ .name = "blue:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF },  // 6
 	{ .name = "green:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 7
-	{ .name = "blue:lan", .default_state = LEDS_GPIO_DEFSTATE_ON },	  // 8
-	DISK_ACT_LED("sata1"),						  // 9
-	DISK_ERR_LED("sata1"),						  // 10
-	DISK_ACT_LED("sata2"),						  // 11
-	DISK_ERR_LED("sata2"),						  // 12
-	DISK_ACT_LED("sata3"),						  // 13
-	DISK_ERR_LED("sata3"),						  // 14
-	DISK_ACT_LED("sata4"),						  // 15
-	DISK_ERR_LED("sata4"),						  // 16
-	DISK_ACT_LED("sata5"),						  // 17
-	DISK_ERR_LED("sata5"),						  // 18
-	DISK_ACT_LED("sata6"),						  // 19
-	DISK_ERR_LED("sata6"),						  // 20
+	{ .name = "blue:lan", .default_state = LEDS_GPIO_DEFSTATE_ON },   // 8
+	DISK_ACT_LED("sata1"),                                            // 9
+	DISK_ERR_LED("sata1"),                                            // 10
+	DISK_ACT_LED("sata2"),                                            // 11
+	DISK_ERR_LED("sata2"),                                            // 12
+	DISK_ACT_LED("sata3"),                                            // 13
+	DISK_ERR_LED("sata3"),                                            // 14
+	DISK_ACT_LED("sata4"),                                            // 15
+	DISK_ERR_LED("sata4"),                                            // 16
+	DISK_ACT_LED("sata5"),                                            // 17
+	DISK_ERR_LED("sata5"),                                            // 18
+	DISK_ACT_LED("sata6"),                                            // 19
+	DISK_ERR_LED("sata6"),                                            // 20
 };
 
 static const struct gpio_led_platform_data asustor_leds_pdata = {
-	.leds	  = asustor_leds,
+	.leds     = asustor_leds,
 	.num_leds = ARRAY_SIZE(asustor_leds),
 };
 
@@ -147,18 +147,18 @@ static struct gpiod_lookup_table asustor_6700_gpio_leds_lookup = {
 // Unfortunately, gpio-keys-polled does not use gpio lookup tables.
 static struct gpio_keys_button asustor_gpio_keys_table[] = {
 	{
-		.desc	    = "USB Copy Button",
-		.code	    = KEY_COPY,
-		.type	    = EV_KEY,
+		.desc       = "USB Copy Button",
+		.code       = KEY_COPY,
+		.type       = EV_KEY,
 		.active_low = 1,
-		.gpio	    = -1, // Invalid, set in init.
+		.gpio       = -1, // Invalid, set in init.
 	},
 	{
-		.desc	    = "Power Button",
-		.code	    = KEY_POWER,
-		.type	    = EV_KEY,
+		.desc       = "Power Button",
+		.code       = KEY_POWER,
+		.type       = EV_KEY,
 		.active_low = 1,
-		.gpio	    = -1, // Invalid, set in init.
+		.gpio       = -1, // Invalid, set in init.
 	},
 };
 
@@ -166,7 +166,7 @@ static struct gpio_keys_platform_data asustor_keys_pdata = {
 	.buttons       = asustor_gpio_keys_table,
 	.nbuttons      = ARRAY_SIZE(asustor_gpio_keys_table),
 	.poll_interval = 50,
-	.name	       = "asustor-keys",
+	.name          = "asustor-keys",
 };
 
 // clang-format off
@@ -251,13 +251,13 @@ static struct platform_device *asustor_leds_pdev;
 static struct platform_device *asustor_keys_pdev;
 
 static struct platform_device *__init asustor_create_pdev(const char *name,
-							  const void *pdata,
-							  size_t sz)
+                                                          const void *pdata,
+                                                          size_t sz)
 {
 	struct platform_device *pdev;
 
 	pdev = platform_device_register_data(NULL, name, PLATFORM_DEVID_NONE,
-					     pdata, sz);
+	                                     pdata, sz);
 	if (IS_ERR(pdev))
 		pr_err("failed registering %s: %ld\n", name, PTR_ERR(pdev));
 
@@ -300,7 +300,7 @@ static int __init asustor_init(void)
 	}
 
 	pr_info("Found %s/%s\n", system->matches[0].substr,
-		system->matches[1].substr);
+	        system->matches[1].substr);
 
 	driver_data = system->driver_data;
 	gpiod_add_lookup_table(driver_data->leds);
@@ -333,7 +333,7 @@ static int __init asustor_init(void)
 
 	asustor_keys_pdev =
 		asustor_create_pdev("gpio-keys-polled", &asustor_keys_pdata,
-				    sizeof(asustor_keys_pdata));
+	                            sizeof(asustor_keys_pdata));
 	if (IS_ERR(asustor_keys_pdev)) {
 		ret = PTR_ERR(asustor_keys_pdev);
 		platform_device_unregister(asustor_leds_pdev);
@@ -365,5 +365,5 @@ MODULE_DESCRIPTION("Platform driver for ASUSTOR NAS hardware");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:asustor");
 MODULE_SOFTDEP("pre: asustor-it87 asustor-gpio-it87 gpio-ich"
-	       " platform:leds-gpio"
-	       " platform:gpio-keys-polled");
+               " platform:leds-gpio"
+               " platform:gpio-keys-polled");

--- a/asustor.c
+++ b/asustor.c
@@ -19,70 +19,53 @@
 #include <linux/platform_device.h>
 #include <linux/version.h>
 
-#define GPIO_IT87                                                              \
-	"asustor_gpio_it87" // use custom patched version for IT8625 support
+#define GPIO_IT87 "asustor_gpio_it87"
 #define GPIO_ICH "gpio_ich"
 #define GPIO_AS6100 "INT33FF:01"
 
-// clang-format off
+#define DISK_ACT_LED(_name)                                                    \
+	{                                                                      \
+		.name		 = _name ":green:disk",                        \
+		.default_state	 = LEDS_GPIO_DEFSTATE_ON,                      \
+		.default_trigger = "disk-activity"                             \
+	}
+#define DISK_ERR_LED(_name)                                                    \
+	{                                                                      \
+		.name	       = _name ":red:disk",                            \
+		.default_state = LEDS_GPIO_DEFSTATE_OFF                        \
+	}
 
 // ASUSTOR Leds.
 // If ledtrig-blkdev ever lands, use that instead of disk-activity:
 // https://lore.kernel.org/linux-leds/20210819025053.222710-1-arequipeno@gmail.com/
 static struct gpio_led asustor_leds[] = {
-	{ .name = "blue:power",   .default_state = LEDS_GPIO_DEFSTATE_ON },    //  0
-	{ .name = "red:power",    .default_state = LEDS_GPIO_DEFSTATE_OFF },   //  1
-	{ .name = "green:status", .default_state = LEDS_GPIO_DEFSTATE_ON },    //  2
+	{ .name		 = "power:front_panel",
+	  .default_state = LEDS_GPIO_DEFSTATE_ON }, // 1
+	{ .name = "power:lcd", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 2
+	{ .name = "blue:power", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 3
+	{ .name = "red:power", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 4
+	{ .name = "green:status", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 5
 	{
-		.name            = "red:status",                                   //  3
-		.default_state   = LEDS_GPIO_DEFSTATE_OFF,
+		.name		 = "red:status",
+		.default_state	 = LEDS_GPIO_DEFSTATE_OFF,
 		.panic_indicator = 1,
 		.default_trigger = "panic",
-	},
-	{ .name = "blue:usb",  .default_state = LEDS_GPIO_DEFSTATE_OFF },      //  4
-	{ .name = "green:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF },      //  5
-	{ .name = "blue:lan",  .default_state = LEDS_GPIO_DEFSTATE_ON },       //  6
-	{
-		.name            = "sata1:green:disk",                             //  7
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata1:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, //  8
-	{
-		.name            = "sata2:green:disk",                             //  9
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata2:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 10
-	{
-		.name            = "sata3:green:disk",                             // 11
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata3:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 12
-	{
-		.name            = "sata4:green:disk",                             // 13
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata4:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 14
-	{ .name = "power:lcd", .default_state = LEDS_GPIO_DEFSTATE_ON },       // 15
-	{
-		.name            = "power:front_panel",                            // 16
-		.default_state   = LEDS_GPIO_DEFSTATE_ON
-	},
-	{
-		.name            = "sata5:green:disk",                             // 17
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata5:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 18
-	{
-		.name            = "sata6:green:disk",                             // 19
-		.default_state   = LEDS_GPIO_DEFSTATE_ON,
-		.default_trigger = "disk-activity",
-	},
-	{ .name = "sata6:red:disk", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 20
+	}, // 6
+	{ .name = "blue:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 7
+	{ .name = "green:usb", .default_state = LEDS_GPIO_DEFSTATE_OFF }, // 8
+	{ .name = "blue:lan", .default_state = LEDS_GPIO_DEFSTATE_ON }, // 9
+	DISK_ACT_LED("sata1"), // 10
+	DISK_ERR_LED("sata1"), // 11
+	DISK_ACT_LED("sata2"), // 12
+	DISK_ERR_LED("sata2"), // 13
+	DISK_ACT_LED("sata3"), // 14
+	DISK_ERR_LED("sata3"), // 15
+	DISK_ACT_LED("sata4"), // 16
+	DISK_ERR_LED("sata4"), // 17
+	DISK_ACT_LED("sata5"), // 18
+	DISK_ERR_LED("sata5"), // 19
+	DISK_ACT_LED("sata6"), // 20
+	DISK_ERR_LED("sata6"), // 21
 };
 
 static const struct gpio_led_platform_data asustor_leds_pdata = {
@@ -90,26 +73,27 @@ static const struct gpio_led_platform_data asustor_leds_pdata = {
 	.num_leds = ARRAY_SIZE(asustor_leds),
 };
 
+// clang-format off
 static struct gpiod_lookup_table asustor_6100_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
-		GPIO_LOOKUP_IDX(GPIO_IT87,   56, NULL,  0, GPIO_ACTIVE_LOW),  // blue:power
-		GPIO_LOOKUP_IDX(GPIO_IT87,    8, NULL,  1, GPIO_ACTIVE_LOW),  // red:power
-		GPIO_LOOKUP_IDX(GPIO_IT87,   31, NULL,  2, GPIO_ACTIVE_LOW),  // green:status
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 21, NULL,  3, GPIO_ACTIVE_HIGH), // red:status
-		// 4
-		GPIO_LOOKUP_IDX(GPIO_IT87,   21, NULL,  5, GPIO_ACTIVE_LOW),  // green:usb
-		GPIO_LOOKUP_IDX(GPIO_IT87,   52, NULL,  6, GPIO_ACTIVE_HIGH), // blue:lan
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 24, NULL,  7, GPIO_ACTIVE_LOW),  // sata1:green:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 15, NULL,  8, GPIO_ACTIVE_HIGH), // sata1:red:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 22, NULL,  9, GPIO_ACTIVE_LOW),  // sata2:green:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 19, NULL, 10, GPIO_ACTIVE_HIGH), // sata2:red:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 25, NULL, 11, GPIO_ACTIVE_LOW),  // sata3:green:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 16, NULL, 12, GPIO_ACTIVE_HIGH), // sata3:red:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 18, NULL, 13, GPIO_ACTIVE_LOW),  // sata4:green:disk
-		GPIO_LOOKUP_IDX(GPIO_AS6100, 17, NULL, 14, GPIO_ACTIVE_HIGH), // sata4:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87,   59, NULL, 15, GPIO_ACTIVE_HIGH), // power:lcd
-		GPIO_LOOKUP_IDX(GPIO_IT87,   29, NULL, 16, GPIO_ACTIVE_HIGH), // power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87,   29, NULL,  0, GPIO_ACTIVE_HIGH), // power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87,   59, NULL,  1, GPIO_ACTIVE_HIGH), // power:lcd
+		GPIO_LOOKUP_IDX(GPIO_IT87,   56, NULL,  2, GPIO_ACTIVE_LOW),  // blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,    8, NULL,  3, GPIO_ACTIVE_LOW),  // red:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,   31, NULL,  4, GPIO_ACTIVE_LOW),  // green:status
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 21, NULL,  5, GPIO_ACTIVE_HIGH), // red:status
+		// 6
+		GPIO_LOOKUP_IDX(GPIO_IT87,   21, NULL,  7, GPIO_ACTIVE_LOW),  // green:usb
+		GPIO_LOOKUP_IDX(GPIO_IT87,   52, NULL,  8, GPIO_ACTIVE_HIGH), // blue:lan
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 24, NULL,  9, GPIO_ACTIVE_LOW),  // sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 15, NULL, 10, GPIO_ACTIVE_HIGH), // sata1:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 22, NULL, 11, GPIO_ACTIVE_LOW),  // sata2:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 19, NULL, 12, GPIO_ACTIVE_HIGH), // sata2:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 25, NULL, 13, GPIO_ACTIVE_LOW),  // sata3:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 16, NULL, 14, GPIO_ACTIVE_HIGH), // sata3:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 18, NULL, 15, GPIO_ACTIVE_LOW),  // sata4:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AS6100, 17, NULL, 16, GPIO_ACTIVE_HIGH), // sata4:red:disk
 		{}
 	},
 };
@@ -117,23 +101,15 @@ static struct gpiod_lookup_table asustor_6100_gpio_leds_lookup = {
 static struct gpiod_lookup_table asustor_600_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
-		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  0, GPIO_ACTIVE_LOW),  // blue:power
-		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  1, GPIO_ACTIVE_LOW),  // red:power
-		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  2, GPIO_ACTIVE_LOW),  // green:status
-		GPIO_LOOKUP_IDX(GPIO_ICH,  27, NULL,  3, GPIO_ACTIVE_HIGH), // red:status
-		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL,  4, GPIO_ACTIVE_LOW),  // blue:usb
-		// 5
-		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL,  6, GPIO_ACTIVE_HIGH), // blue:lan
+		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL, 0, GPIO_ACTIVE_HIGH), // power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL, 1, GPIO_ACTIVE_HIGH), // power:lcd
+		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL, 2, GPIO_ACTIVE_LOW),  // blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL, 3, GPIO_ACTIVE_LOW),  // red:power
+		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL, 4, GPIO_ACTIVE_LOW),  // green:status
+		GPIO_LOOKUP_IDX(GPIO_ICH,  27, NULL, 5, GPIO_ACTIVE_HIGH), // red:status
+		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL, 6, GPIO_ACTIVE_LOW),  // blue:usb
 		// 7
-		// 8
-		// 9
-		// 10
-		// 11
-		// 12
-		// 13
-		// 14
-		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL, 15, GPIO_ACTIVE_HIGH), // power:lcd
-		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL, 16, GPIO_ACTIVE_HIGH), // power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 8, GPIO_ACTIVE_HIGH), // blue:lan
 		{}
 	},
 };
@@ -141,23 +117,23 @@ static struct gpiod_lookup_table asustor_600_gpio_leds_lookup = {
 static struct gpiod_lookup_table asustor_6700_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
-		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  0, GPIO_ACTIVE_LOW),	// blue:power
-		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  1, GPIO_ACTIVE_LOW),	// red:power
-		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  2, GPIO_ACTIVE_LOW),	// green:status
-		GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  3, GPIO_ACTIVE_LOW),	// red:status
-		// 4
-		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL,  5, GPIO_ACTIVE_LOW),	// green:usb
-		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  6, GPIO_ACTIVE_HIGH),	// blue:lan
-		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  7, GPIO_ACTIVE_HIGH),	// sata1:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL,  8, GPIO_ACTIVE_LOW),	// sata1:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 46, NULL,  9, GPIO_ACTIVE_HIGH),	// sata2:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 47, NULL, 10, GPIO_ACTIVE_LOW),	// sata2:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 51, NULL, 11, GPIO_ACTIVE_HIGH),	// sata3:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 12, GPIO_ACTIVE_LOW),	// sata3:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 63, NULL, 13, GPIO_ACTIVE_HIGH),	// sata4:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 48, NULL, 14, GPIO_ACTIVE_LOW),	// sata4:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL, 15, GPIO_ACTIVE_HIGH),	// power:lcd
-		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL, 16, GPIO_ACTIVE_HIGH),	// power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
+		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
+		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
+		GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
+		// 6
+		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL,  7, GPIO_ACTIVE_LOW),	// green:usb
+		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
+		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 46, NULL, 11, GPIO_ACTIVE_HIGH),	// sata2:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 47, NULL, 12, GPIO_ACTIVE_LOW),	// sata2:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 51, NULL, 13, GPIO_ACTIVE_HIGH),	// sata3:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 14, GPIO_ACTIVE_LOW),	// sata3:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 63, NULL, 15, GPIO_ACTIVE_HIGH),	// sata4:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 48, NULL, 16, GPIO_ACTIVE_LOW),	// sata4:red:disk
 		GPIO_LOOKUP_IDX(GPIO_IT87, 61, NULL, 17, GPIO_ACTIVE_HIGH),	// sata5:green:disk
 		GPIO_LOOKUP_IDX(GPIO_IT87, 62, NULL, 18, GPIO_ACTIVE_LOW),	// sata5:red:disk
 		GPIO_LOOKUP_IDX(GPIO_IT87, 58, NULL, 19, GPIO_ACTIVE_HIGH),	// sata6:green:disk


### PR DESCRIPTION
This PR re-orders GPIOs so it's more natural to add additional disk GPIOs.

@DanielGibson I would appreciate it if you could review/try this out to ensure I didn't mess up the ordering.