### PR TITLE
Add support for FS67xx series (FS6712X, probably FS6706T)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ On many systems, ASUSTOR uses a mix of IT87 and CPU GPIOs to control leds and bu
 - AS6602T, AS6604T (NOT TESTED!)
 - AS6702T, AS6704T
 - AS5402T, AS5404T
+- FS6706T (NOT TESTED!), FS6712X
 - .. possibly more, if they're similar enough.
   The following DMI system-manufacturer / system-product-name combinations are currently supported
   (see `sudo dmidecode -s system-manufacturer` and `sudo dmidecode -s system-product-name`):

--- a/asustor.c
+++ b/asustor.c
@@ -34,6 +34,16 @@
 		.name          = _name ":red:disk",                            \
 		.default_state = LEDS_GPIO_DEFSTATE_OFF                        \
 	}
+#define NVME_ACT_LED(_name)                                                    \
+	{                                                                      \
+		.name          = _name ":green:disk",                          \
+		.default_state = LEDS_GPIO_DEFSTATE_OFF                        \
+	}
+#define NVME_ERR_LED(_name)                                                    \
+	{                                                                      \
+		.name          = _name ":red:disk",                            \
+		.default_state = LEDS_GPIO_DEFSTATE_OFF                        \
+	}
 
 // ASUSTOR Leds.
 // If ledtrig-blkdev ever lands, use that instead of disk-activity:
@@ -66,6 +76,8 @@ static struct gpio_led asustor_leds[] = {
 	DISK_ERR_LED("sata5"),                                            // 18
 	DISK_ACT_LED("sata6"),                                            // 19
 	DISK_ERR_LED("sata6"),                                            // 20
+	NVME_ACT_LED("nvme1"),                                            // 21
+	NVME_ERR_LED("nvme1"),                                            // 22
 };
 
 static const struct gpio_led_platform_data asustor_leds_pdata = {
@@ -90,8 +102,20 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
 		// 6
 		// 7
 		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
-		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_LOW),	// sata1:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		// 9
+		// 10
+		// 11
+		// 12
+		// 13
+		// 14
+		// 15
+		// 16
+		// 17
+		// 18
+		// 19
+		// 20
+		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL, 21, GPIO_ACTIVE_LOW),	// nvme1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 22, GPIO_ACTIVE_LOW),	// nvme1:red:disk
 		{}
 	},
 };

--- a/asustor.c
+++ b/asustor.c
@@ -346,8 +346,12 @@ static int __init asustor_init(void)
 		return -ENODEV;
 	}
 
-	pr_info("Found %s/%s\n", system->matches[0].substr,
-	        system->matches[1].substr);
+	if (strlen(system->matches[2].substr))
+		pr_info("Found %s/%s/%s\n", system->matches[0].substr,
+	        	system->matches[1].substr, system->matches[2].substr);
+	else
+		pr_info("Found %s/%s\n", system->matches[0].substr,
+	        	system->matches[1].substr);
 
 	driver_data = system->driver_data;
 	gpiod_add_lookup_table(driver_data->leds);
@@ -378,9 +382,8 @@ static int __init asustor_init(void)
 		goto err;
 	}
 
-	asustor_keys_pdev =
-		asustor_create_pdev("gpio-keys-polled", &asustor_keys_pdata,
-	                            sizeof(asustor_keys_pdata));
+	asustor_keys_pdev = asustor_create_pdev(
+		"gpio-keys-polled", &asustor_keys_pdata, sizeof(asustor_keys_pdata));
 	if (IS_ERR(asustor_keys_pdev)) {
 		ret = PTR_ERR(asustor_keys_pdev);
 		platform_device_unregister(asustor_leds_pdev);

--- a/asustor.c
+++ b/asustor.c
@@ -192,7 +192,7 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_keys_lookup = {
 	.dev_id = "gpio-keys-polled",
 	.table = {
 		// 0 (There is no USB Copy Button).
-		GPIO_LOOKUP_IDX(GPIO_IT87, 32, NULL, 1, GPIO_ACTIVE_LOW),
+		// 1 (Power Button is already handled properly via ACPI).
 		{}
 	},
 };
@@ -244,6 +244,16 @@ static struct asustor_driver_data asustor_600_driver_data = {
 
 static const struct dmi_system_id asustor_systems[] = {
 	{
+		// Note: This uses the BIOS release date to help match the FS67xx,
+		//       because otherwise it matches the AS670xT, AS540xT and others
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Jasper Lake Client Platform"),
+			DMI_EXACT_MATCH(DMI_BIOS_DATE, "09/15/2023"),
+		},
+		.driver_data = &asustor_fs6700_driver_data,
+	},
+	{
 		// Note: This not only matches (and works with) AS670xT (Lockerstore Gen2),
 		//       but also AS540xT (Nimbustor Gen2)
 		.matches = {
@@ -252,8 +262,9 @@ static const struct dmi_system_id asustor_systems[] = {
 		},
 		.driver_data = &asustor_6700_driver_data,
 	},
-	// the same also seemed to work with AS6602T, though I can't test that anymore
 	{
+		// Note: The same also seemed to work with AS6602T,
+		//	 though I can't test that anymore
 		.matches = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Insyde"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "GeminiLake"),

--- a/asustor.c
+++ b/asustor.c
@@ -77,8 +77,12 @@ static const struct gpio_led_platform_data asustor_leds_pdata = {
 static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
-		//GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
-		//GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
+										// Red LEDs to the left and right of the
+										// power button on the side of the unit
+		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL,  0, GPIO_ACTIVE_LOW),	// power:front_panel
+		// 1
+										// Also controls the red LED inside the
+										// power button on the side of the unit
 		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
 		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
 		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
@@ -88,6 +92,34 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
 		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
 		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_LOW),	// sata1:green:disk
 		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		{}
+	},
+};
+
+static struct gpiod_lookup_table asustor_6700_gpio_leds_lookup = {
+	.dev_id = "leds-gpio",
+	.table = {
+		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
+		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
+		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
+		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
+		GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
+		// 6
+		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL,  7, GPIO_ACTIVE_LOW),	// green:usb
+		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
+		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 46, NULL, 11, GPIO_ACTIVE_HIGH),	// sata2:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 47, NULL, 12, GPIO_ACTIVE_LOW),	// sata2:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 51, NULL, 13, GPIO_ACTIVE_HIGH),	// sata3:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 14, GPIO_ACTIVE_LOW),	// sata3:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 63, NULL, 15, GPIO_ACTIVE_HIGH),	// sata4:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 48, NULL, 16, GPIO_ACTIVE_LOW),	// sata4:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 61, NULL, 17, GPIO_ACTIVE_HIGH),	// sata5:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 62, NULL, 18, GPIO_ACTIVE_LOW),	// sata5:red:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 58, NULL, 19, GPIO_ACTIVE_HIGH),	// sata6:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 60, NULL, 20, GPIO_ACTIVE_LOW),	// sata6:red:disk
 		{}
 	},
 };
@@ -128,34 +160,6 @@ static struct gpiod_lookup_table asustor_600_gpio_leds_lookup = {
 		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL, 6, GPIO_ACTIVE_LOW),  // blue:usb
 		// 7
 		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 8, GPIO_ACTIVE_HIGH), // blue:lan
-		{}
-	},
-};
-
-static struct gpiod_lookup_table asustor_6700_gpio_leds_lookup = {
-	.dev_id = "leds-gpio",
-	.table = {
-		GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
-		GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
-		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
-		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
-		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
-		GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
-		// 6
-		GPIO_LOOKUP_IDX(GPIO_IT87, 21, NULL,  7, GPIO_ACTIVE_LOW),	// green:usb
-		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
-		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 46, NULL, 11, GPIO_ACTIVE_HIGH),	// sata2:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 47, NULL, 12, GPIO_ACTIVE_LOW),	// sata2:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 51, NULL, 13, GPIO_ACTIVE_HIGH),	// sata3:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL, 14, GPIO_ACTIVE_LOW),	// sata3:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 63, NULL, 15, GPIO_ACTIVE_HIGH),	// sata4:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 48, NULL, 16, GPIO_ACTIVE_LOW),	// sata4:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 61, NULL, 17, GPIO_ACTIVE_HIGH),	// sata5:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 62, NULL, 18, GPIO_ACTIVE_LOW),	// sata5:red:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 58, NULL, 19, GPIO_ACTIVE_HIGH),	// sata6:green:disk
-		GPIO_LOOKUP_IDX(GPIO_IT87, 60, NULL, 20, GPIO_ACTIVE_LOW),	// sata6:red:disk
 		{}
 	},
 };

--- a/asustor.c
+++ b/asustor.c
@@ -81,8 +81,8 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
 										// power button on the side of the unit
 		GPIO_LOOKUP_IDX(GPIO_IT87, 52, NULL,  0, GPIO_ACTIVE_LOW),	// power:front_panel
 		// 1
-										// Also controls the red LED inside the
-										// power button on the side of the unit
+										// blue:power also controls the red LED
+										// inside the power button on the side
 		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
 		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
 		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status

--- a/asustor.c
+++ b/asustor.c
@@ -79,14 +79,14 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
 	.table = {
 		//GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
 		//GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
-		//GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
 		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
 		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
-		//GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
+		GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
 		// 6
 		// 7
-		//GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
-		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
+		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_LOW),	// sata1:green:disk
 		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
 		{}
 	},

--- a/asustor.c
+++ b/asustor.c
@@ -74,6 +74,24 @@ static const struct gpio_led_platform_data asustor_leds_pdata = {
 };
 
 // clang-format off
+static struct gpiod_lookup_table asustor_fs6700_gpio_leds_lookup = {
+	.dev_id = "leds-gpio",
+	.table = {
+		//GPIO_LOOKUP_IDX(GPIO_IT87, 29, NULL,  0, GPIO_ACTIVE_HIGH),	// power:front_panel
+		//GPIO_LOOKUP_IDX(GPIO_IT87, 59, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
+		//GPIO_LOOKUP_IDX(GPIO_IT87, 56, NULL,  2, GPIO_ACTIVE_LOW),	// blue:power
+		GPIO_LOOKUP_IDX(GPIO_IT87,  8, NULL,  3, GPIO_ACTIVE_LOW),	// red:power
+		GPIO_LOOKUP_IDX(GPIO_IT87, 31, NULL,  4, GPIO_ACTIVE_LOW),	// green:status
+		//GPIO_LOOKUP_IDX(GPIO_IT87, 49, NULL,  5, GPIO_ACTIVE_LOW),	// red:status
+		// 6
+		// 7
+		//GPIO_LOOKUP_IDX(GPIO_IT87, 55, NULL,  8, GPIO_ACTIVE_HIGH),	// blue:lan
+		GPIO_LOOKUP_IDX(GPIO_IT87, 12, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_IT87, 13, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		{}
+	},
+};
+
 static struct gpiod_lookup_table asustor_6100_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
@@ -170,6 +188,15 @@ static struct gpio_keys_platform_data asustor_keys_pdata = {
 };
 
 // clang-format off
+static struct gpiod_lookup_table asustor_fs6700_gpio_keys_lookup = {
+	.dev_id = "gpio-keys-polled",
+	.table = {
+		// 0 (There is no USB Copy Button).
+		GPIO_LOOKUP_IDX(GPIO_IT87, 32, NULL, 1, GPIO_ACTIVE_LOW),
+		{}
+	},
+};
+
 static struct gpiod_lookup_table asustor_6100_gpio_keys_lookup = { // same for 6700
 	.dev_id = "gpio-keys-polled",
 	.table = {
@@ -193,6 +220,11 @@ static struct gpiod_lookup_table asustor_600_gpio_keys_lookup = {
 struct asustor_driver_data {
 	struct gpiod_lookup_table *leds;
 	struct gpiod_lookup_table *keys;
+};
+
+static struct asustor_driver_data asustor_fs6700_driver_data = {
+	.leds = &asustor_fs6700_gpio_leds_lookup,
+	.keys = &asustor_fs6700_gpio_keys_lookup,
 };
 
 static struct asustor_driver_data asustor_6700_driver_data = {


### PR DESCRIPTION
This adds support for the FS6712X and probably the FS6706T since its the same unit with less PCIe switches and muxes.  All of the LEDs have been tested on my unit as well as the single power button.

This unit doesn't have a front panel, but there are some LEDs on the side next to the power button that can be toggled and I treated the same.  The blue:power LED also controls a red LED inside the power button; I couldn't find a way to separate these through GPIO lines.

I moved the `asustor_6700_gpio_leds_lookup` struct in the code so the order is consistently fs6700, 6700, 6100, 600.  This is just a consistency thing; its otherwise unchanged.

For DMI system matching, I added the BIOS release date from my FS6712X.  This is probably the only questionable change because I only have this one unit, so I can't see how this BIOS date compares to another Jasper Lake ASUSTOR.  I've attached the DMI data from my system if someone wants to compare with other Jasper Lake ASUSTOR systems to see if BIOS date is a suitable differentiator.

[dmi.txt](https://github.com/user-attachments/files/16592415/dmi.txt)

The `pr_info` call (module loading text) has been adjusted to print the third DMI match parameter, if it exists.

I tried to make notes in comments a little more consistent as well as a variable initialization statement.  Minor consistency stuff again, no actual content changes.

Lastly, these units are all NVMe devices, and the default Linux kernel doesn't have a LED trigger for NVMe activity.  `disk-activity` doesn't work for PCIe devices and the Linux kernel maintainers can't decide on the right approach.  Again, we have to hope for `ledtrig-blk` or something here, but the disk activity LED could be used for other purposes in the meantime.  So, I created NVME* macros that default the LEDs to off and no `disk-activity` trigger, and used these for the fs6700 series.

## Summary by GitHub Copilot ##

This pull request introduces support for the FS6706T and FS6712X models, adds NVMe LED definitions, and refactors the GPIO lookup tables for better organization and clarity. The most important changes include updates to the README file, new LED definitions, and modifications to the GPIO lookup tables and driver data structures.

### Model Support Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39): Added FS6706T (not tested) and FS6712X to the list of supported models.

### LED Definitions:
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R37-R46): Added new NVMe activity and error LED definitions (`NVME_ACT_LED` and `NVME_ERR_LED`).
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R79-R80): Included NVMe LED entries in the `asustor_leds` array.

### GPIO Lookup Tables:
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R89-R150): Added new GPIO lookup tables for FS6700 and 6700 models, organizing LED and key mappings. [[1]](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R89-R150) [[2]](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R219-R227)
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3L116-L143): Removed the old GPIO lookup table for the 6700 model to avoid duplication and improve clarity.

### Driver Data Structures:
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R253-R257): Added driver data for the FS6700 model, linking it to the new GPIO lookup tables.
* [`asustor.c`](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3L223-R295): Updated the `asustor_init` function to print additional information and reformat existing code for readability. [[1]](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3L223-R295) [[2]](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3R373-R376) [[3]](diffhunk://#diff-c2f17092c45b293625e88d80ad9fae24b241f1f5f81535112dc780c47840e9c3L334-R410)