### PR TITLE
Support AS5304T and AS6302T

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On many systems, ASUSTOR uses a mix of IT87 and CPU GPIOs to control leds and bu
 
 ### Optional
 
-- `it87` (AS6, AS61, AS62, AS66XX, AS67XX, AS54XX, FS67XX)
+- `it87` (AS6, AS61, AS62, AS66XX, AS67XX, AS53xx, AS54XX, FS67XX)
   - This project includes a patched version of `it87` called `asustor-it87` which skips fan pwm sanity checks
     and supports more variants of IT86XX and the IT87XX chips than the kernels `it87` driver.
     Support for timer-based blinking of up to two LEDs (only works on some models) has also been added.
@@ -33,8 +33,10 @@ On many systems, ASUSTOR uses a mix of IT87 and CPU GPIOs to control leds and bu
 - AS604T
 - AS6104T (NOT TESTED!)
 - AS6204T
+- AS6302T
 - AS6602T, AS6604T (NOT TESTED!)
 - AS6702T, AS6704T, AS6706T
+- AS5304T
 - AS5402T, AS5404T (NOT TESTED!)
 - FS6706T, FS6712X
 - .. possibly more, if they're similar enough.
@@ -46,9 +48,13 @@ The following DMI system-manufacturer / system-product-name combinations are cur
 * "Insyde" / "AS61xx"
     - Identified by `asustor` kernel module as **"AS61xx"**
 * "Insyde" / "GeminiLake"
-    - These are the *Lockerstor* AS66xxT devices, like AS6604T
+    - These are the *Lockerstor* AS66xxT devices, like AS6604T or *Nimbustor* AS53xxT (AS5304T) devices.
         - *maybe also others like Nimbustor AS520xT?*
-    - Identified by `asustor` kernel module as **"AS66xx"**
+    - Identified by `asustor` kernel module as:
+      - **"AS66xx"** for *Lockerstor* (AS6602T and AS6604T)
+      - **"AS53xx"** for *Nimbustor* (AS5304T)
+* "Intel Corporation" / "Apollolake I Platform"
+    - Identified by `asustor` kernel module as **"AS63xx"** (AS6302T known to work)
 * "Intel Corporation" / "Jasper Lake Client Platform"
     - These are the *Lockerstor Gen2* AS67xxT (AS6702T etc), *Nimbustor Gen2* AS54xxT (AS5402T etc)
       and *Flashstor* FS6706T/FS6712X devices.

--- a/asustor_main.c
+++ b/asustor_main.c
@@ -457,7 +457,7 @@ static struct asustor_driver_data asustor_5304_driver_data = {
 	.name = "AS53xx",
 	.pci_matches = {
 		// ASMedia ASM2806 4-Port PCIe x2 Gen3 Packet Switch
-		// (does NOT exist here, but on AS602T and AS604T)
+		// (does NOT exist here, but on AS6602T and AS6604T)
 		{ 0x1b21, 0x2806, 0, 0 }
 	},
 	.leds = &asustor_5304_gpio_leds_lookup,
@@ -468,7 +468,7 @@ static struct asustor_driver_data asustor_6600_driver_data = {
 	.name = "AS66xx",
 	.pci_matches = {
 		// ASMedia ASM2806 4-Port PCIe x2 Gen3 Packet Switch
-		// (exists on AS602T and AS604T, but not AS5304T)
+		// (exists on AS6602T and AS6604T, but not AS5304T)
 		// in the lspci outputs I've seen both had 5 such devices,
 		// but let's be a bit more flexible here..
 		{ 0x1b21, 0x2806, 3, DEVICE_COUNT_MAX }
@@ -484,8 +484,8 @@ static struct asustor_driver_data asustor_6600_driver_data = {
 
 /*
  * It currently looks like the older systems are easier to tell apart, at least if one doesn't insist
- * on detecting the 2 vs 4 vs 6 drives versions (I only did this for AS67xx because I had to do the
- * advanced detection anyway)
+ * on detecting the 2 vs 4 vs 6 drives versions (this was only done for AS67xx because there the
+ * advanced detection had to be done anyway)
  */
 
 static struct asustor_driver_data asustor_6300_driver_data = {
@@ -580,10 +580,10 @@ static const struct dmi_system_id asustor_systems[] = {
 	},
 	// older devices can be matched only by DMI
 	{
-		// AS 63xx
+		// AS63xx
 		.matches = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),
-			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Apollolake I Platform")
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Apollolake I Platform"),
 		},
 		.driver_data = &asustor_6300_driver_data,
 	},


### PR DESCRIPTION
based on patch from
https://github.com/mafredri/asustor-platform-driver/discussions/37

added detection logic based on PCI devices

Needs testing by people owning AS5304T, AS6302T (@Tki2000), as well as people owning **AS66xxT** (because AS5304T was formerly wrongly detected as AS66xx).