### PR TITLE
Add support for AS6806T (Lockerstor Gen3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ asustor_gpio_it87_DEST_DIR = $(KERNEL_MODULES)/kernel/drivers/gpio
 
 obj-m  := $(patsubst %,%.o,$(DRIVER))
 obj-ko := $(patsubst %,%.ko,$(DRIVER))
-# asustor.o is built from two source files for license reasons
-asustor-y := asustor_main.o asustor_gpl2.o
+# asustor.o is built from multiple source files for license reasons
+asustor-y := asustor_main.o asustor_gpl2.o asustor_mcu.o asustor_lcm.o
 
 all: modules
 
@@ -40,9 +40,9 @@ dkms:
 	@mkdir -p $(DKMS_ROOT_PATH_ASUSTOR)
 	@echo "obj-m := asustor.o" >>$(DKMS_ROOT_PATH_ASUSTOR)/Makefile
 	@echo "obj-ko := asustor.ko" >>$(DKMS_ROOT_PATH_ASUSTOR)/Makefile
-	@echo "asustor-y := asustor_main.o asustor_gpl2.o" >>$(DKMS_ROOT_PATH_ASUSTOR)/Makefile
+	@echo "asustor-y := asustor_main.o asustor_gpl2.o asustor_mcu.o asustor_lcm.o" >>$(DKMS_ROOT_PATH_ASUSTOR)/Makefile
 	@cp dkms.conf $(DKMS_ROOT_PATH_ASUSTOR)
-	@cp asustor_main.c asustor_gpl2.c $(DKMS_ROOT_PATH_ASUSTOR)
+	@cp asustor_main.c asustor_gpl2.c asustor_mcu.c asustor_mcu.h asustor_lcm.c asustor_lcm.h $(DKMS_ROOT_PATH_ASUSTOR)
 	@sed -i -e '/^PACKAGE_VERSION=/ s/=.*/=\"$(DRIVER_VERSION)\"/' $(DKMS_ROOT_PATH_ASUSTOR)/dkms.conf
 
 	@mkdir -p $(DKMS_ROOT_PATH_ASUSTOR_IT87)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ On many systems, ASUSTOR uses a mix of IT87 and CPU GPIOs to control leds and bu
 - AS6702T, AS6704T, AS6706T
 - AS5402T, AS5404T (NOT TESTED!)
 - FS6706T, FS6712X
+- AS6806T (Gen3, AMD Rembrandt)
 - .. possibly more, if they're similar enough.
 
 The following DMI system-manufacturer / system-product-name combinations are currently supported
@@ -58,6 +59,11 @@ The following DMI system-manufacturer / system-product-name combinations are cur
         * **"AS6706"** for *Lockerstor Gen2* with *six* SATA drives (AS6706T)
         * **"FS6706"** for *Flashtor* with *six* slots for m.2 NVME SSDs (FS6706T)
         * **"FS6712"** for *Flashtor* with *twelve* slots for m.2 NVME SSDs (FS6712X)
+* "AMD" / "Rembrandt"
+    - These are the *Lockerstor Gen3* AS68xxT devices, like AS6806T
+    - Uses AMD FCH GPIO (`AMDI0030:00`) instead of IT87, and an onboard MCU for fan control and status LEDs
+    - Identified by `asustor` kernel module as:
+        * **"AS6806"** for *Lockerstor Gen3* with *six* SATA drives (AS6806T)
 
 ## Features
 
@@ -75,9 +81,35 @@ The following DMI system-manufacturer / system-product-name combinations are cur
 - Buttons
   - USB Copy Button
   - Power Button (AS6)
+  - LCD Navigation Buttons (AS6806T) — 4 buttons (Up, Down, Back, Enter) next to the front-panel LCD
 - Power (`/sys/class/leds/power:*`)
   - LCD
   - Front panel
+
+### AS6806T (Gen3) Specific Features
+
+The AS6806T uses a different hardware architecture (AMD Rembrandt) from the Intel-based models.
+It does **not** use an IT87 chip — the `asustor-it87` and `asustor-gpio-it87` modules are not needed.
+
+- **GPIO**: AMD FCH (`AMDI0030:00`, `pinctrl-amd` kernel driver). No custom GPIO driver needed.
+- **Fan control**: Via onboard MCU over serial (`/dev/ttyS1`). Exposed at `/sys/class/hwmon/hwmon*/pwm1`.
+  Fan RPM is also read via the MCU and exposed at `/sys/class/hwmon/hwmon*/fan1_input`.
+- **MCU-controlled LEDs**: Power LED (blue + red) and status LED (green + red) are controlled by
+  the MCU, not GPIO. Exposed as `/sys/class/leds/blue:power`, `red:power`, `green:status`, `red:status`.
+- **Front-panel LCD**: 16×2 character display controlled via serial (`/dev/ttyS2`). Requires GPIO
+  power (`power:lcd` LED). Exposed via sysfs:
+  - `/sys/devices/platform/asustor_lcm/lcd_line0` — write top line (max 16 chars)
+  - `/sys/devices/platform/asustor_lcm/lcd_line1` — write bottom line (max 16 chars)
+  - `/sys/devices/platform/asustor_lcm/lcd_clear` — clear display (write `1`)
+- **LCD Navigation Buttons**: 4 buttons arranged in a 2×2 grid next to the LCD. Reported as a
+  Linux input device (`ASUSTOR LCD Buttons`). The buttons are part of the LCD module and
+  communicate via the same serial port (`/dev/ttyS2`). Use `evtest` to monitor events.
+  - ↑ Up → `KEY_UP`
+  - ↓ Down → `KEY_DOWN`
+  - ← Back → `KEY_ESC`
+  - ↵ Enter → `KEY_ENTER`
+- **Temperature**: Use `nct7802` kernel module (`modprobe nct7802`) for temperature sensors via
+  I2C (bus 1, address 0x2E). Also: `k10temp` for CPU temperature.
 
 ## Installation
 

--- a/asustor_lcm.c
+++ b/asustor_lcm.c
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * asustor_lcm.c - Front-panel LCD module for ASUSTOR NAS hardware
+ *
+ * Communicates with the front-panel LCD controller via /dev/ttyS2 at 9600 baud
+ * (8N1) using a framed packet protocol (0xF0 header + checksum).
+ *
+ * The LCD is a 16x2 character display. GPIO power must be enabled before use
+ * (handled by the power:lcd LED in the main asustor driver).
+ *
+ * The LCD module also has 4 navigation buttons. When pressed, the LCD controller
+ * sends unsolicited F0 packets with CMD 0x80 containing the button ID. A receive
+ * thread reads these packets and reports button events via a Linux input device.
+ *
+ * Provides sysfs attributes:
+ *   /sys/devices/platform/asustor_lcm/lcd_line0  — top line text (16 chars)
+ *   /sys/devices/platform/asustor_lcm/lcd_line1  — bottom line text (16 chars)
+ *   /sys/devices/platform/asustor_lcm/lcd_clear  — write-only, clears display
+ *
+ * Copyright (C) 2026 Thierry Tremblay
+ */
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/delay.h>
+#include <linux/input.h>
+#include <linux/kthread.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <linux/string.h>
+#include <linux/tty.h>
+#include <linux/tty_driver.h>
+
+#include "asustor_lcm.h"
+
+/* LCD serial port parameters */
+#define LCM_SERIAL_PORT		"/dev/ttyS2"
+#define LCM_BAUD_RATE		B9600
+
+/* LCD framed protocol constants */
+#define LCM_FRAME_HEADER	0xF0
+#define LCM_FRAME_ACK_HEADER	0xF1
+#define LCM_FRAME_MAX_SIZE	22
+
+/* LCD commands (sent by host) */
+#define LCM_CMD_TEXT		0x27
+
+/* LCD commands (received from LCD controller) */
+#define LCM_CMD_BUTTON		0x80	/* button press event */
+
+/* LCD button IDs (data byte in CMD 0x80 packets) */
+#define LCM_BTN_UP		1
+#define LCM_BTN_DOWN		2
+#define LCM_BTN_BACK		3
+#define LCM_BTN_ENTER		4
+
+/* LCD display dimensions */
+#define LCM_WIDTH		16
+#define LCM_NUM_LINES		2
+
+/* Receive thread poll interval */
+#define LCM_RX_POLL_MS		2000
+#define LCM_RX_READ_TIMEOUT_US	500000	/* 500ms per-byte timeout */
+#define LCM_RX_MAX_RETRIES	20	/* max consecutive read failures */
+
+struct asustor_lcm {
+	struct mutex lock;		/* serializes LCD communication */
+	struct file *tty_filp;
+	struct platform_device *pdev;
+	char line_cache[LCM_NUM_LINES][LCM_WIDTH + 1]; /* cached display text */
+	struct input_dev *input_dev;	/* input device for LCD buttons */
+	struct task_struct *rx_thread;	/* serial receive thread */
+};
+
+static struct asustor_lcm *lcm_data;
+
+/* ---- Low-level serial I/O ---- */
+
+static struct file *lcm_serial_open(void)
+{
+	struct file *f;
+	struct tty_struct *tty;
+	struct ktermios termios;
+
+	f = filp_open(LCM_SERIAL_PORT, O_RDWR | O_NOCTTY | O_NONBLOCK, 0);
+	if (IS_ERR(f)) {
+		pr_err("failed to open %s: %ld\n", LCM_SERIAL_PORT, PTR_ERR(f));
+		return f;
+	}
+
+	tty = ((struct tty_file_private *)f->private_data)->tty;
+	if (!tty) {
+		pr_err("failed to get tty struct\n");
+		filp_close(f, NULL);
+		return ERR_PTR(-ENODEV);
+	}
+
+	/* Configure 9600 8N1 raw */
+	termios = tty->termios;
+	termios.c_iflag = 0;
+	termios.c_oflag = 0;
+	termios.c_cflag = LCM_BAUD_RATE | CS8 | CREAD | CLOCAL;
+	termios.c_lflag = 0;
+	termios.c_cc[VMIN] = 0;
+	termios.c_cc[VTIME] = 1;	/* 100ms timeout */
+	tty_set_termios(tty, &termios);
+
+	return f;
+}
+
+static void lcm_serial_close(struct file *f)
+{
+	if (!IS_ERR_OR_NULL(f))
+		filp_close(f, NULL);
+}
+
+/* Compute 8-bit checksum: sum of all bytes in the packet */
+static u8 lcm_checksum(const u8 *buf, int len)
+{
+	u8 sum = 0;
+	int i;
+
+	for (i = 0; i < len; i++)
+		sum += buf[i];
+	return sum;
+}
+
+/*
+ * Send a framed packet to the LCD controller.
+ * Packet format: [0xF0] [N] [CMD] [DATA_0..DATA_{N-1}] [CHECKSUM]
+ * where N = number of data bytes after CMD, total size = N + 4.
+ *
+ * Must be called with lcm->lock held.
+ */
+static int lcm_send_frame(struct asustor_lcm *lcm, u8 cmd,
+			   const u8 *data, int data_len)
+{
+	u8 frame[LCM_FRAME_MAX_SIZE];
+	int frame_len;
+	loff_t pos = 0;
+	int ret;
+
+	frame_len = data_len + 4;	/* header + length + cmd + data + checksum */
+	if (frame_len > LCM_FRAME_MAX_SIZE)
+		return -EINVAL;
+
+	frame[0] = LCM_FRAME_HEADER;
+	frame[1] = data_len;
+	frame[2] = cmd;
+	if (data_len > 0)
+		memcpy(&frame[3], data, data_len);
+	frame[frame_len - 1] = lcm_checksum(frame, frame_len - 1);
+
+	ret = kernel_write(lcm->tty_filp, frame, frame_len, &pos);
+	if (ret < 0)
+		return ret;
+	if (ret != frame_len)
+		return -EIO;
+
+	return 0;
+}
+
+/* Read a single byte from the serial port. Returns 0 on success, -ETIMEDOUT or error. */
+static int lcm_read_byte(struct asustor_lcm *lcm, u8 *byte)
+{
+	loff_t pos = 0;
+	int ret;
+
+	ret = kernel_read(lcm->tty_filp, byte, 1, &pos);
+	if (ret == 1)
+		return 0;
+	if (ret == 0 || ret == -EAGAIN)
+		return -ETIMEDOUT;
+	return ret;
+}
+
+/*
+ * Read a framed packet from the LCD controller.
+ * Scans for 0xF0 or 0xF1 header, then reads length + cmd + data + checksum.
+ * Returns total packet length on success, or negative error.
+ */
+static int lcm_recv_frame(struct asustor_lcm *lcm, u8 *buf, int buf_size)
+{
+	u8 byte;
+	int ret, data_len, frame_len, i;
+	u8 expected_cs;
+
+	/* Scan for frame header */
+	ret = lcm_read_byte(lcm, &byte);
+	if (ret)
+		return ret;
+
+	if (byte != LCM_FRAME_HEADER && byte != LCM_FRAME_ACK_HEADER)
+		return -EPROTO;
+
+	buf[0] = byte;
+
+	/* Read length byte */
+	ret = lcm_read_byte(lcm, &buf[1]);
+	if (ret)
+		return ret;
+
+	data_len = buf[1];
+	frame_len = data_len + 4; /* header + length + cmd + data + checksum */
+	if (frame_len > buf_size || frame_len > LCM_FRAME_MAX_SIZE)
+		return -EPROTO;
+
+	/* Read cmd + data + checksum */
+	for (i = 2; i < frame_len; i++) {
+		ret = lcm_read_byte(lcm, &buf[i]);
+		if (ret)
+			return ret;
+	}
+
+	/* Verify checksum */
+	expected_cs = lcm_checksum(buf, frame_len - 1);
+	if (buf[frame_len - 1] != expected_cs) {
+		pr_debug("checksum mismatch: got 0x%02x, expected 0x%02x\n",
+			 buf[frame_len - 1], expected_cs);
+		return -EPROTO;
+	}
+
+	return frame_len;
+}
+
+/* Send an F1 ACK response for a received command */
+static void lcm_send_ack(struct asustor_lcm *lcm, u8 cmd)
+{
+	u8 ack[5];
+	loff_t pos = 0;
+
+	ack[0] = LCM_FRAME_ACK_HEADER;
+	ack[1] = 0x01;		/* 1 data byte */
+	ack[2] = cmd;
+	ack[3] = 0x00;		/* status: OK */
+	ack[4] = lcm_checksum(ack, 4);
+
+	kernel_write(lcm->tty_filp, ack, sizeof(ack), &pos);
+}
+
+/* Map LCD button ID to Linux input key code */
+static unsigned int lcm_button_to_keycode(u8 button_id)
+{
+	switch (button_id) {
+	case LCM_BTN_UP:	return KEY_UP;
+	case LCM_BTN_DOWN:	return KEY_DOWN;
+	case LCM_BTN_BACK:	return KEY_ESC;
+	case LCM_BTN_ENTER:	return KEY_ENTER;
+	default:		return KEY_UNKNOWN;
+	}
+}
+
+static int lcm_rx_thread(void *data)
+{
+	struct asustor_lcm *lcm = data;
+	u8 frame[LCM_FRAME_MAX_SIZE];
+	int ret;
+
+	while (!kthread_should_stop()) {
+		ret = lcm_recv_frame(lcm, frame, sizeof(frame));
+		if (ret < 0) {
+			if (ret == -ETIMEDOUT) {
+				/* No data available — sleep and retry */
+				msleep_interruptible(100);
+				continue;
+			}
+			/* Protocol error — skip and retry */
+			pr_debug("rx frame error: %d\n", ret);
+			continue;
+		}
+
+		/* Only process F0 packets (LCD-initiated) */
+		if (frame[0] != LCM_FRAME_HEADER)
+			continue;
+
+		/* Send ACK */
+		mutex_lock(&lcm->lock);
+		lcm_send_ack(lcm, frame[2]);
+		mutex_unlock(&lcm->lock);
+
+		/* Handle button press (CMD 0x80, 1 data byte = button ID) */
+		if (frame[2] == LCM_CMD_BUTTON && frame[1] >= 1) {
+			u8 button_id = frame[3];
+			unsigned int keycode = lcm_button_to_keycode(button_id);
+
+			if (keycode != KEY_UNKNOWN) {
+				input_report_key(lcm->input_dev, keycode, 1);
+				input_sync(lcm->input_dev);
+				input_report_key(lcm->input_dev, keycode, 0);
+				input_sync(lcm->input_dev);
+			}
+			pr_debug("button press: id=%d keycode=%d\n",
+				 button_id, keycode);
+		}
+	}
+
+	return 0;
+}
+
+/* ---- LCD command helpers (must be called with lock held) ---- */
+
+static int lcm_cmd_write_line(struct asustor_lcm *lcm, int line,
+			      const char *text)
+{
+	u8 data[2 + LCM_WIDTH];	/* line + col + 16 chars */
+	int len, i;
+
+	if (line < 0 || line >= LCM_NUM_LINES)
+		return -EINVAL;
+
+	data[0] = line;
+	data[1] = 0x00;		/* column = 0 */
+
+	len = strnlen(text, LCM_WIDTH);
+	memcpy(&data[2], text, len);
+
+	/* Pad remaining characters with spaces */
+	for (i = len; i < LCM_WIDTH; i++)
+		data[2 + i] = ' ';
+
+	return lcm_send_frame(lcm, LCM_CMD_TEXT, data, sizeof(data));
+}
+
+/* ---- sysfs attributes ---- */
+
+static ssize_t lcd_line0_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	struct asustor_lcm *lcm = lcm_data;
+
+	return sysfs_emit(buf, "%s\n", lcm->line_cache[0]);
+}
+
+static ssize_t lcd_line0_store(struct device *dev,
+			       struct device_attribute *attr,
+			       const char *buf, size_t count)
+{
+	struct asustor_lcm *lcm = lcm_data;
+	char text[LCM_WIDTH + 1];
+	int len, ret;
+
+	len = min_t(int, count, LCM_WIDTH);
+
+	/* Strip trailing newline */
+	if (len > 0 && buf[len - 1] == '\n')
+		len--;
+
+	memcpy(text, buf, len);
+	text[len] = '\0';
+
+	mutex_lock(&lcm->lock);
+	ret = lcm_cmd_write_line(lcm, 0, text);
+	if (ret == 0) {
+		memset(lcm->line_cache[0], 0, sizeof(lcm->line_cache[0]));
+		memcpy(lcm->line_cache[0], text, len);
+	}
+	mutex_unlock(&lcm->lock);
+
+	return ret < 0 ? ret : count;
+}
+
+static ssize_t lcd_line1_show(struct device *dev,
+			      struct device_attribute *attr, char *buf)
+{
+	struct asustor_lcm *lcm = lcm_data;
+
+	return sysfs_emit(buf, "%s\n", lcm->line_cache[1]);
+}
+
+static ssize_t lcd_line1_store(struct device *dev,
+			       struct device_attribute *attr,
+			       const char *buf, size_t count)
+{
+	struct asustor_lcm *lcm = lcm_data;
+	char text[LCM_WIDTH + 1];
+	int len, ret;
+
+	len = min_t(int, count, LCM_WIDTH);
+
+	/* Strip trailing newline */
+	if (len > 0 && buf[len - 1] == '\n')
+		len--;
+
+	memcpy(text, buf, len);
+	text[len] = '\0';
+
+	mutex_lock(&lcm->lock);
+	ret = lcm_cmd_write_line(lcm, 1, text);
+	if (ret == 0) {
+		memset(lcm->line_cache[1], 0, sizeof(lcm->line_cache[1]));
+		memcpy(lcm->line_cache[1], text, len);
+	}
+	mutex_unlock(&lcm->lock);
+
+	return ret < 0 ? ret : count;
+}
+
+static ssize_t lcd_clear_store(struct device *dev,
+			       struct device_attribute *attr,
+			       const char *buf, size_t count)
+{
+	struct asustor_lcm *lcm = lcm_data;
+	int ret;
+
+	mutex_lock(&lcm->lock);
+	ret = lcm_cmd_write_line(lcm, 0, "");
+	if (ret == 0)
+		ret = lcm_cmd_write_line(lcm, 1, "");
+	if (ret == 0)
+		memset(lcm->line_cache, 0, sizeof(lcm->line_cache));
+	mutex_unlock(&lcm->lock);
+
+	return ret < 0 ? ret : count;
+}
+
+static DEVICE_ATTR_RW(lcd_line0);
+static DEVICE_ATTR_RW(lcd_line1);
+static DEVICE_ATTR_WO(lcd_clear);
+
+static struct attribute *asustor_lcm_attrs[] = {
+	&dev_attr_lcd_line0.attr,
+	&dev_attr_lcd_line1.attr,
+	&dev_attr_lcd_clear.attr,
+	NULL
+};
+
+static const struct attribute_group asustor_lcm_attr_group = {
+	.attrs = asustor_lcm_attrs,
+};
+
+/* ---- Init / Cleanup ---- */
+
+int __init asustor_lcm_init(const char *model_name)
+{
+	struct asustor_lcm *lcm;
+	struct input_dev *input;
+	struct file *f;
+	struct platform_device *pdev;
+	int ret;
+
+	/* Only AS6806T has the front-panel LCD on ttyS2 */
+	if (strcmp(model_name, "AS6806") != 0)
+		return 0;
+
+	pr_info("initializing LCM on %s\n", LCM_SERIAL_PORT);
+
+	lcm = kzalloc(sizeof(*lcm), GFP_KERNEL);
+	if (!lcm)
+		return -ENOMEM;
+
+	mutex_init(&lcm->lock);
+
+	/* Open serial port */
+	f = lcm_serial_open();
+	if (IS_ERR(f)) {
+		ret = PTR_ERR(f);
+		goto err_free;
+	}
+	lcm->tty_filp = f;
+	lcm_data = lcm;
+
+	/* Create platform device for sysfs */
+	pdev = platform_device_register_simple("asustor_lcm", -1, NULL, 0);
+	if (IS_ERR(pdev)) {
+		ret = PTR_ERR(pdev);
+		pr_err("failed to register platform device: %d\n", ret);
+		goto err_serial;
+	}
+	lcm->pdev = pdev;
+
+	ret = sysfs_create_group(&pdev->dev.kobj, &asustor_lcm_attr_group);
+	if (ret) {
+		pr_err("failed to create sysfs group: %d\n", ret);
+		goto err_pdev;
+	}
+
+	/* Register input device for LCD navigation buttons */
+	input = input_allocate_device();
+	if (!input) {
+		ret = -ENOMEM;
+		pr_err("failed to allocate input device\n");
+		goto err_sysfs;
+	}
+
+	input->name = "ASUSTOR LCD Buttons";
+	input->phys = "asustor_lcm/input0";
+	input->id.bustype = BUS_RS232;
+	input->dev.parent = &pdev->dev;
+
+	input_set_capability(input, EV_KEY, KEY_UP);
+	input_set_capability(input, EV_KEY, KEY_DOWN);
+	input_set_capability(input, EV_KEY, KEY_ESC);
+	input_set_capability(input, EV_KEY, KEY_ENTER);
+
+	ret = input_register_device(input);
+	if (ret) {
+		pr_err("failed to register input device: %d\n", ret);
+		input_free_device(input);
+		goto err_sysfs;
+	}
+	lcm->input_dev = input;
+
+	/* Start receive thread for button events */
+	lcm->rx_thread = kthread_run(lcm_rx_thread, lcm, "asustor_lcm_rx");
+	if (IS_ERR(lcm->rx_thread)) {
+		ret = PTR_ERR(lcm->rx_thread);
+		pr_err("failed to start rx thread: %d\n", ret);
+		lcm->rx_thread = NULL;
+		goto err_input;
+	}
+
+	pr_info("LCM initialized (16x2 display + 4 buttons on %s at 9600 baud)\n",
+		LCM_SERIAL_PORT);
+
+	return 0;
+
+err_input:
+	input_unregister_device(lcm->input_dev);
+err_sysfs:
+	sysfs_remove_group(&pdev->dev.kobj, &asustor_lcm_attr_group);
+err_pdev:
+	platform_device_unregister(pdev);
+err_serial:
+	lcm_serial_close(lcm->tty_filp);
+err_free:
+	lcm_data = NULL;
+	kfree(lcm);
+	return ret;
+}
+
+void __exit asustor_lcm_cleanup(void)
+{
+	struct asustor_lcm *lcm = lcm_data;
+
+	if (!lcm)
+		return;
+
+	if (lcm->rx_thread)
+		kthread_stop(lcm->rx_thread);
+	if (lcm->input_dev)
+		input_unregister_device(lcm->input_dev);
+	sysfs_remove_group(&lcm->pdev->dev.kobj, &asustor_lcm_attr_group);
+	platform_device_unregister(lcm->pdev);
+	lcm_serial_close(lcm->tty_filp);
+	lcm_data = NULL;
+	kfree(lcm);
+
+	pr_info("LCM cleaned up\n");
+}

--- a/asustor_lcm.h
+++ b/asustor_lcm.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef ASUSTOR_LCM_H
+#define ASUSTOR_LCM_H
+
+int __init asustor_lcm_init(const char *model_name);
+void __exit asustor_lcm_cleanup(void);
+
+#endif /* ASUSTOR_LCM_H */

--- a/asustor_main.c
+++ b/asustor_main.c
@@ -21,9 +21,13 @@
 #include <linux/platform_device.h>
 #include <linux/version.h>
 
+#include "asustor_lcm.h"
+#include "asustor_mcu.h"
+
 #define GPIO_IT87 "asustor_gpio_it87"
 #define GPIO_ICH "gpio_ich"
 #define GPIO_AS6100 "INT33FF:01"
+#define GPIO_AMD_FCH "AMDI0030:00"
 
 #define DISK_ACT_LED(_name)                                                    \
 	{                                                                      \
@@ -190,6 +194,34 @@ static struct gpiod_lookup_table asustor_as6706_gpio_leds_lookup = {
 	},
 };
 
+static struct gpiod_lookup_table asustor_as6806_gpio_leds_lookup = {
+	.dev_id = "leds-gpio",
+	.table = {
+		// 0: power:front_panel — controlled by embedded controller (not GPIO)
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,   4, NULL,  1, GPIO_ACTIVE_HIGH),	// power:lcd
+		// 2: blue:power — controlled by embedded controller (not GPIO)
+		// 3: red:power — controlled by embedded controller (not GPIO)
+		// 4: green:status — controlled by embedded controller (not GPIO)
+		// 5: red:status — controlled by embedded controller (not GPIO)
+		// 6: blue:usb — N/A
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 147, NULL,  7, GPIO_ACTIVE_HIGH),	// green:usb (backup button LED)
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 148, NULL,  8, GPIO_ACTIVE_LOW),	// blue:lan
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  69, NULL,  9, GPIO_ACTIVE_HIGH),	// sata1:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  68, NULL, 10, GPIO_ACTIVE_LOW),	// sata1:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  75, NULL, 11, GPIO_ACTIVE_HIGH),	// sata2:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  74, NULL, 12, GPIO_ACTIVE_LOW),	// sata2:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  79, NULL, 13, GPIO_ACTIVE_HIGH),	// sata3:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH,  78, NULL, 14, GPIO_ACTIVE_LOW),	// sata3:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 106, NULL, 15, GPIO_ACTIVE_HIGH),	// sata4:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 107, NULL, 16, GPIO_ACTIVE_LOW),	// sata4:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 146, NULL, 17, GPIO_ACTIVE_LOW),	// sata5:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 145, NULL, 18, GPIO_ACTIVE_HIGH),	// sata5:red:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 154, NULL, 19, GPIO_ACTIVE_HIGH),	// sata6:green:disk
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 156, NULL, 20, GPIO_ACTIVE_LOW),	// sata6:red:disk
+		{}
+	},
+};
+
 static struct gpiod_lookup_table asustor_6100_gpio_leds_lookup = {
 	.dev_id = "leds-gpio",
 	.table = {
@@ -267,6 +299,17 @@ static struct gpiod_lookup_table asustor_fs6700_gpio_keys_lookup = {
 	},
 };
 
+static struct gpiod_lookup_table asustor_as6806_gpio_keys_lookup = {
+	.dev_id = "gpio-keys-polled",
+	.table = {
+		GPIO_LOOKUP_IDX(GPIO_AMD_FCH, 89, NULL, 0, GPIO_ACTIVE_LOW),
+		// Front panel LCD navigation buttons (1-4 + enter) are driven
+		// by an embedded controller, not directly via GPIO.
+		// Power Button is already handled properly via ACPI.
+		{}
+	},
+};
+
 static struct gpiod_lookup_table asustor_6100_gpio_keys_lookup = { // same for 6700
 	.dev_id = "gpio-keys-polled",
 	.table = {
@@ -313,7 +356,7 @@ struct asustor_driver_data {
 };
 
 #define VALID_OVERRIDE_NAMES                                                   \
-	"AS6xx, AS61xx, AS66xx, AS6702, AS6704, AS6706, FS6706, FS6712"
+	"AS6xx, AS61xx, AS66xx, AS6702, AS6704, AS6706, AS6806, FS6706, FS6712"
 
 // NOTE: if you add another device here, update VALID_OVERRIDE_NAMES accordingly!
 
@@ -384,6 +427,17 @@ static struct asustor_driver_data asustor_fs6712_driver_data = {
 	},
 	.leds = &asustor_fs6700_gpio_leds_lookup,
 	.keys = &asustor_fs6700_gpio_keys_lookup,
+};
+
+static struct asustor_driver_data asustor_as6806_driver_data = {
+	.name = "AS6806",
+	.pci_matches = {
+		// SATA controller [0106]: ASMedia Technology Inc. ASM1166 Serial ATA Controller [1b21:1166]
+		// Same PCI device as AS6706T, but distinguished by DMI vendor (AMD vs Intel Corporation)
+		{ 0x1b21, 0x1166, 1, 1 }
+	},
+	.leds = &asustor_as6806_gpio_leds_lookup,
+	.keys = &asustor_as6806_gpio_keys_lookup,
 };
 
 static struct asustor_driver_data asustor_fs6706_driver_data = {
@@ -484,6 +538,15 @@ static const struct dmi_system_id asustor_systems[] = {
 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Jasper Lake Client Platform"),
 		},
 		.driver_data = &asustor_fs6712_driver_data,
+	},
+
+	// AS68xx (LockerStor Gen3) - AMD Rembrandt platform
+	{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "AMD"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Rembrandt"),
+		},
+		.driver_data = &asustor_as6806_driver_data,
 	},
 
 	// older devices can be matched only by DMI
@@ -727,6 +790,19 @@ static int __init asustor_init(void)
 		goto err;
 	}
 
+	/* Initialize MCU for models that use it (AS68xx) */
+	ret = asustor_mcu_init(driver_data->name);
+	if (ret) {
+		pr_warn("MCU init failed: %d (non-fatal)\n", ret);
+		/* Non-fatal — GPIO LEDs and buttons still work */
+	}
+
+	/* Initialize front-panel LCD module (AS6806T) */
+	ret = asustor_lcm_init(driver_data->name);
+	if (ret) {
+		pr_warn("LCM init failed: %d (non-fatal)\n", ret);
+	}
+
 	return 0;
 
 err:
@@ -737,6 +813,9 @@ err:
 
 static void __exit asustor_cleanup(void)
 {
+	asustor_lcm_cleanup();
+	asustor_mcu_cleanup();
+
 	platform_device_unregister(asustor_leds_pdev);
 	platform_device_unregister(asustor_keys_pdev);
 
@@ -751,6 +830,7 @@ MODULE_AUTHOR("Mathias Fredriksson <mafredri@gmail.com>");
 MODULE_DESCRIPTION("Platform driver for ASUSTOR NAS hardware");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:asustor");
-MODULE_SOFTDEP("pre: asustor-it87 asustor-gpio-it87 gpio-ich"
+MODULE_SOFTDEP("pre: asustor-it87 asustor-gpio-it87 gpio-ich pinctrl-amd"
                " platform:leds-gpio"
-               " platform:gpio-keys-polled");
+               " platform:gpio-keys-polled"
+               " ledtrig-timer");

--- a/asustor_mcu.c
+++ b/asustor_mcu.c
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * asustor_mcu.c - MCU serial communication for ASUSTOR AS68xx (Gen3) NAS hardware
+ *
+ * Communicates with the onboard AS72XXR MCU via /dev/ttyS1 at 115200 baud (8N1).
+ * Provides:
+ *   - hwmon interface for fan PWM control
+ *   - LED class devices for power and status LEDs
+ *
+ * Copyright (C) 2026 Thierry Tremblay
+ */
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/delay.h>
+#include <linux/hwmon.h>
+#include <linux/leds.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/platform_device.h>
+#include <linux/tty.h>
+#include <linux/tty_driver.h>
+
+#include "asustor_mcu.h"
+
+/* MCU command bytes */
+#define MCU_CMD_SET_FAN_PWM	0x30
+#define MCU_CMD_GET_FAN		0x31
+#define MCU_CMD_GET_FAN_RPM_LO	0x10	/* sub-cmd: RPM low byte */
+#define MCU_CMD_GET_FAN_RPM_HI	0x11	/* sub-cmd: RPM high byte */
+#define MCU_CMD_SET_LED		0x10
+#define MCU_CMD_LED_SUBCMD_LIGHT 0x02
+#define MCU_CMD_LED_SUBCMD_PWM	0x03
+#define MCU_CMD_GET_VERSION	0x41
+
+/* MCU LED base values (OFF byte) — add mode offset for other states */
+#define MCU_LED_POWER_BLUE	0x98
+#define MCU_LED_POWER_ORANGE	0x68
+#define MCU_LED_STATUS_GREEN	0x70
+#define MCU_LED_STATUS_RED	0x78
+
+/* MCU LED mode offsets from base value */
+#define MCU_LED_MODE_OFF		0x00
+#define MCU_LED_MODE_ON			0x03
+#define MCU_LED_MODE_BLINK_SLOW		0x04
+#define MCU_LED_MODE_BLINK_MED		0x05
+#define MCU_LED_MODE_BLINK_FAST		0x06
+#define MCU_LED_MODE_BLINK_FASTEST	0x07
+
+/* MCU communication parameters */
+#define MCU_SERIAL_PORT		"/dev/ttyS1"
+#define MCU_BAUD_RATE		115200
+#define MCU_TX_LEN		3
+#define MCU_RX_MAX_LEN		8
+#define MCU_RESP_TIMEOUT_MS	500
+#define MCU_CMD_DELAY_US	100000	/* 100ms between commands */
+#define MCU_FAN_DEFAULT_PWM	0x55
+
+struct asustor_mcu {
+	struct mutex lock;	/* serializes MCU communication */
+	struct file *tty_filp;
+	struct platform_device *pdev;
+
+	/* hwmon */
+	struct device *hwmon_dev;
+	u8 fan_pwm;		/* cached PWM value */
+
+};
+
+static struct asustor_mcu *mcu_data;
+
+/* ---- Low-level serial I/O ---- */
+
+static struct file *mcu_serial_open(void)
+{
+	struct file *f;
+	struct tty_struct *tty;
+	struct ktermios termios;
+
+	f = filp_open(MCU_SERIAL_PORT, O_RDWR | O_NOCTTY | O_NONBLOCK, 0);
+	if (IS_ERR(f)) {
+		pr_err("failed to open %s: %ld\n", MCU_SERIAL_PORT, PTR_ERR(f));
+		return f;
+	}
+
+	tty = ((struct tty_file_private *)f->private_data)->tty;
+	if (!tty) {
+		pr_err("failed to get tty struct\n");
+		filp_close(f, NULL);
+		return ERR_PTR(-ENODEV);
+	}
+
+	/* Configure 115200 8N1 raw */
+	termios = tty->termios;
+	termios.c_iflag = 0;
+	termios.c_oflag = 0;
+	termios.c_cflag = B115200 | CS8 | CREAD | CLOCAL;
+	termios.c_lflag = 0;
+	termios.c_cc[VMIN] = 0;
+	termios.c_cc[VTIME] = 5;	/* 500ms timeout */
+	tty_set_termios(tty, &termios);
+
+	return f;
+}
+
+static void mcu_serial_close(struct file *f)
+{
+	if (!IS_ERR_OR_NULL(f))
+		filp_close(f, NULL);
+}
+
+static int mcu_send_cmd(struct asustor_mcu *mcu, const u8 *cmd, int cmd_len,
+			u8 *resp, int resp_len)
+{
+	struct file *f = mcu->tty_filp;
+	loff_t pos = 0;
+	int ret;
+	int i;
+
+	if (IS_ERR_OR_NULL(f))
+		return -ENODEV;
+
+	/* Write command */
+	ret = kernel_write(f, cmd, cmd_len, &pos);
+	if (ret < 0)
+		return ret;
+	if (ret != cmd_len)
+		return -EIO;
+
+	if (!resp || resp_len == 0)
+		return 0;
+
+	/* Wait for response */
+	usleep_range(MCU_RESP_TIMEOUT_MS * 500, MCU_RESP_TIMEOUT_MS * 1000);
+
+	/* Read response */
+	pos = 0;
+	memset(resp, 0, resp_len);
+	for (i = 0; i < resp_len; i++) {
+		ret = kernel_read(f, &resp[i], 1, &pos);
+		if (ret <= 0)
+			break;
+	}
+
+	return i;	/* return number of bytes read */
+}
+
+static int mcu_cmd_locked(struct asustor_mcu *mcu, const u8 *cmd, int cmd_len,
+			  u8 *resp, int resp_len)
+{
+	int ret;
+
+	mutex_lock(&mcu->lock);
+	ret = mcu_send_cmd(mcu, cmd, cmd_len, resp, resp_len);
+	mutex_unlock(&mcu->lock);
+
+	return ret;
+}
+
+/* ---- hwmon (fan control) ---- */
+
+static int mcu_fan_get_pwm(struct asustor_mcu *mcu)
+{
+	u8 cmd[] = { MCU_CMD_GET_FAN, 0x00, 0x00 };
+	u8 resp[6];
+	int ret;
+
+	ret = mcu_cmd_locked(mcu, cmd, sizeof(cmd), resp, sizeof(resp));
+	if (ret >= 6) {
+		mcu->fan_pwm = resp[5];
+		return resp[5];
+	}
+	return ret < 0 ? ret : -EIO;
+}
+
+static int mcu_fan_get_rpm(struct asustor_mcu *mcu)
+{
+	u8 cmd_lo[] = { MCU_CMD_GET_FAN, MCU_CMD_GET_FAN_RPM_LO, 0x00 };
+	u8 cmd_hi[] = { MCU_CMD_GET_FAN, MCU_CMD_GET_FAN_RPM_HI, 0x00 };
+	u8 resp[6];
+	int ret;
+	u8 lo, hi;
+
+	mutex_lock(&mcu->lock);
+
+	ret = mcu_send_cmd(mcu, cmd_lo, sizeof(cmd_lo), resp, sizeof(resp));
+	if (ret < 6) {
+		mutex_unlock(&mcu->lock);
+		return ret < 0 ? ret : -EIO;
+	}
+	lo = resp[5];
+
+	ret = mcu_send_cmd(mcu, cmd_hi, sizeof(cmd_hi), resp, sizeof(resp));
+	if (ret < 6) {
+		mutex_unlock(&mcu->lock);
+		return ret < 0 ? ret : -EIO;
+	}
+	hi = resp[5];
+
+	mutex_unlock(&mcu->lock);
+
+	return (hi << 8) | lo;
+}
+
+static int mcu_fan_set_pwm(struct asustor_mcu *mcu, u8 duty)
+{
+	u8 cmd[] = { MCU_CMD_SET_FAN_PWM, 0x00, duty };
+	int ret;
+
+	ret = mcu_cmd_locked(mcu, cmd, sizeof(cmd), NULL, 0);
+	if (ret >= 0)
+		mcu->fan_pwm = duty;
+	return ret;
+}
+
+static umode_t asustor_mcu_hwmon_is_visible(const void *data,
+					    enum hwmon_sensor_types type,
+					    u32 attr, int channel)
+{
+	if (type == hwmon_pwm) {
+		switch (attr) {
+		case hwmon_pwm_input:
+			return 0644;
+		case hwmon_pwm_enable:
+			return 0644;
+		default:
+			return 0;
+		}
+	}
+	if (type == hwmon_fan) {
+		switch (attr) {
+		case hwmon_fan_input:
+			return 0444;
+		default:
+			return 0;
+		}
+	}
+	return 0;
+}
+
+static int asustor_mcu_hwmon_read(struct device *dev,
+				  enum hwmon_sensor_types type,
+				  u32 attr, int channel, long *val)
+{
+	struct asustor_mcu *mcu = dev_get_drvdata(dev);
+
+	if (type == hwmon_fan) {
+		switch (attr) {
+		case hwmon_fan_input:
+			*val = mcu_fan_get_rpm(mcu);
+			if (*val < 0)
+				return *val;
+			return 0;
+		default:
+			return -EOPNOTSUPP;
+		}
+	}
+
+	if (type != hwmon_pwm)
+		return -EOPNOTSUPP;
+
+	switch (attr) {
+	case hwmon_pwm_input:
+		*val = mcu_fan_get_pwm(mcu);
+		if (*val < 0)
+			return *val;
+		return 0;
+	case hwmon_pwm_enable:
+		*val = 1;	/* always manual mode */
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int asustor_mcu_hwmon_write(struct device *dev,
+				   enum hwmon_sensor_types type,
+				   u32 attr, int channel, long val)
+{
+	struct asustor_mcu *mcu = dev_get_drvdata(dev);
+
+	if (type != hwmon_pwm)
+		return -EOPNOTSUPP;
+
+	switch (attr) {
+	case hwmon_pwm_input:
+		if (val < 0 || val > 255)
+			return -EINVAL;
+		return mcu_fan_set_pwm(mcu, val);
+	case hwmon_pwm_enable:
+		/* Only manual mode supported */
+		if (val != 1)
+			return -EINVAL;
+		return 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static const struct hwmon_channel_info *asustor_mcu_hwmon_info[] = {
+	HWMON_CHANNEL_INFO(fan, HWMON_F_INPUT),
+	HWMON_CHANNEL_INFO(pwm, HWMON_PWM_INPUT | HWMON_PWM_ENABLE),
+	NULL
+};
+
+static const struct hwmon_ops asustor_mcu_hwmon_ops = {
+	.is_visible = asustor_mcu_hwmon_is_visible,
+	.read       = asustor_mcu_hwmon_read,
+	.write      = asustor_mcu_hwmon_write,
+};
+
+static const struct hwmon_chip_info asustor_mcu_hwmon_chip_info = {
+	.ops  = &asustor_mcu_hwmon_ops,
+	.info = asustor_mcu_hwmon_info,
+};
+
+/* ---- LED class devices ---- */
+
+struct mcu_led {
+	struct led_classdev cdev;
+	u8 base_val;	/* MCU OFF byte — add MCU_LED_MODE_* for other states */
+};
+
+static int mcu_led_brightness_set(struct led_classdev *cdev,
+				  enum led_brightness brightness)
+{
+	struct mcu_led *led = container_of(cdev, struct mcu_led, cdev);
+	u8 mode = brightness ? MCU_LED_MODE_ON : MCU_LED_MODE_OFF;
+	u8 cmd[] = { MCU_CMD_SET_LED, MCU_CMD_LED_SUBCMD_LIGHT,
+		     led->base_val + mode };
+
+	return mcu_cmd_locked(mcu_data, cmd, sizeof(cmd), NULL, 0);
+}
+
+/* MCU hardware blink speeds — symmetric 50% duty cycle, measured on AS6806T */
+static const struct {
+	unsigned long delay;	/* half-period in ms */
+	u8 mode;
+} mcu_blink_speeds[] = {
+	{ 500, MCU_LED_MODE_BLINK_SLOW },
+	{ 250, MCU_LED_MODE_BLINK_MED },
+	{ 125, MCU_LED_MODE_BLINK_FAST },
+	{  62, MCU_LED_MODE_BLINK_FASTEST },
+};
+
+static int mcu_led_blink_set(struct led_classdev *cdev,
+			     unsigned long *delay_on,
+			     unsigned long *delay_off)
+{
+	struct mcu_led *led = container_of(cdev, struct mcu_led, cdev);
+	unsigned long period = *delay_on + *delay_off;
+	unsigned long best_diff = ~0UL;
+	int best = 0;
+	int i;
+	u8 cmd[3];
+
+	/* Default to slow blink if both delays are zero */
+	if (period == 0)
+		period = 1000;
+
+	for (i = 0; i < ARRAY_SIZE(mcu_blink_speeds); i++) {
+		unsigned long hw_period = 2 * mcu_blink_speeds[i].delay;
+		unsigned long diff = (period > hw_period) ?
+			period - hw_period : hw_period - period;
+
+		if (diff < best_diff) {
+			best = i;
+			best_diff = diff;
+		}
+	}
+
+	*delay_on = mcu_blink_speeds[best].delay;
+	*delay_off = mcu_blink_speeds[best].delay;
+
+	cmd[0] = MCU_CMD_SET_LED;
+	cmd[1] = MCU_CMD_LED_SUBCMD_LIGHT;
+	cmd[2] = led->base_val + mcu_blink_speeds[best].mode;
+
+	return mcu_cmd_locked(mcu_data, cmd, sizeof(cmd), NULL, 0);
+}
+
+static struct mcu_led mcu_leds[] = {
+	{
+		.cdev = {
+			.name			 = "blue:power",
+			.brightness_set_blocking = mcu_led_brightness_set,
+			.blink_set		 = mcu_led_blink_set,
+			.max_brightness		 = 1,
+			.default_trigger	 = "default-on",
+		},
+		.base_val = MCU_LED_POWER_BLUE,
+	},
+	{
+		.cdev = {
+			.name			 = "orange:power",
+			.brightness_set_blocking = mcu_led_brightness_set,
+			.blink_set		 = mcu_led_blink_set,
+			.max_brightness		 = 1,
+		},
+		.base_val = MCU_LED_POWER_ORANGE,
+	},
+	{
+		.cdev = {
+			.name			 = "green:status",
+			.brightness_set_blocking = mcu_led_brightness_set,
+			.blink_set		 = mcu_led_blink_set,
+			.max_brightness		 = 1,
+			.default_trigger	 = "timer",
+		},
+		.base_val = MCU_LED_STATUS_GREEN,
+	},
+	{
+		.cdev = {
+			.name			 = "red:status",
+			.brightness_set_blocking = mcu_led_brightness_set,
+			.blink_set		 = mcu_led_blink_set,
+			.max_brightness		 = 1,
+			.default_trigger	 = "panic",
+		},
+		.base_val = MCU_LED_STATUS_RED,
+	},
+};
+
+/* ---- Init / Cleanup ---- */
+
+int __init asustor_mcu_init(const char *model_name)
+{
+	struct asustor_mcu *mcu;
+	struct file *f;
+	struct platform_device *pdev;
+	int ret, i;
+
+	/* Only AS6806T uses the MCU */
+	if (strcmp(model_name, "AS6806") != 0)
+		return 0;
+
+	pr_info("initializing MCU on %s\n", MCU_SERIAL_PORT);
+
+	mcu = kzalloc(sizeof(*mcu), GFP_KERNEL);
+	if (!mcu)
+		return -ENOMEM;
+
+	mutex_init(&mcu->lock);
+
+	/* Open serial port */
+	f = mcu_serial_open();
+	if (IS_ERR(f)) {
+		ret = PTR_ERR(f);
+		goto err_free;
+	}
+	mcu->tty_filp = f;
+	mcu_data = mcu;
+
+	/* Create a platform device as parent for hwmon */
+	pdev = platform_device_register_simple("asustor_mcu", -1, NULL, 0);
+	if (IS_ERR(pdev)) {
+		ret = PTR_ERR(pdev);
+		pr_err("failed to register platform device: %d\n", ret);
+		goto err_serial;
+	}
+	mcu->pdev = pdev;
+
+	/* Register hwmon for fan control */
+	mcu->hwmon_dev = hwmon_device_register_with_info(&pdev->dev, "asustor_mcu",
+			mcu, &asustor_mcu_hwmon_chip_info, NULL);
+	if (IS_ERR(mcu->hwmon_dev)) {
+		ret = PTR_ERR(mcu->hwmon_dev);
+		pr_err("failed to register hwmon: %d\n", ret);
+		goto err_pdev;
+	}
+
+	/* Register MCU LEDs */
+	for (i = 0; i < ARRAY_SIZE(mcu_leds); i++) {
+		ret = led_classdev_register(NULL, &mcu_leds[i].cdev);
+		if (ret) {
+			pr_err("failed to register LED %s: %d\n",
+			       mcu_leds[i].cdev.name, ret);
+			goto err_leds;
+		}
+	}
+
+	/* Apply a sane startup speed, then read back the current PWM for logging. */
+	ret = mcu_fan_set_pwm(mcu, MCU_FAN_DEFAULT_PWM);
+	if (ret < 0)
+		pr_warn("failed to set default fan PWM: %d\n", ret);
+	ret = mcu_fan_get_pwm(mcu);
+	if (ret < 0)
+		pr_warn("failed to read initial fan PWM: %d\n", ret);
+	pr_info("MCU initialized, fan PWM: %d\n", mcu->fan_pwm);
+
+	return 0;
+
+err_leds:
+	while (--i >= 0)
+		led_classdev_unregister(&mcu_leds[i].cdev);
+	hwmon_device_unregister(mcu->hwmon_dev);
+err_pdev:
+	platform_device_unregister(mcu->pdev);
+err_serial:
+	mcu_serial_close(mcu->tty_filp);
+err_free:
+	mcu_data = NULL;
+	kfree(mcu);
+	return ret;
+}
+
+void __exit asustor_mcu_cleanup(void)
+{
+	struct asustor_mcu *mcu = mcu_data;
+	int i;
+
+	if (!mcu)
+		return;
+
+	for (i = 0; i < ARRAY_SIZE(mcu_leds); i++)
+		led_classdev_unregister(&mcu_leds[i].cdev);
+
+	hwmon_device_unregister(mcu->hwmon_dev);
+	platform_device_unregister(mcu->pdev);
+	mcu_serial_close(mcu->tty_filp);
+	mcu_data = NULL;
+	kfree(mcu);
+
+	pr_info("MCU cleaned up\n");
+}

--- a/asustor_mcu.h
+++ b/asustor_mcu.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef ASUSTOR_MCU_H
+#define ASUSTOR_MCU_H
+
+int __init asustor_mcu_init(const char *model_name);
+void __exit asustor_mcu_cleanup(void);
+
+#endif /* ASUSTOR_MCU_H */


### PR DESCRIPTION
Add AS6806T (AMD Rembrandt platform) support with:

- GPIO LED control via AMD FCH: 15 LEDs including 6 SATA disk
  activity/error pairs, USB backup, LAN, and LCD power
- MCU serial communication (ttyS1, 115200 baud) providing:
  - hwmon interface for fan PWM control and RPM reading
  - LED class devices for power (blue/orange) and status (green/red)
    LEDs with hardware blink support (4 MCU blink speeds)
- Front-panel LCD module (ttyS2, 9600 baud) with sysfs interface for
  16x2 character display (lcd_line0, lcd_line1, lcd_clear)
- LCD navigation buttons: 4 buttons (Up, Down, Back, Enter) in a 2x2
  grid next to the LCD, reported as a Linux input device via the same
  serial port. The LCD controller sends button events as F0-framed
  packets which are read by a kernel thread.
- USB copy button via GPIO-polled keys
- DMI detection (AMD/Rembrandt) with ASM1166 PCI match to distinguish
  from Intel-based AS6706T which shares the same SATA controller
- pinctrl-amd and ledtrig-timer added to MODULE_SOFTDEP

Tested on AS6806T hardware.